### PR TITLE
Clear Cache NPM Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "scripts": {
     "build": "concurrently -c \"magenta,blue\" \"npm:theme.bundle.prod\" \"npm:theme.bundle.admin\"",
+    "clear-cache": "rm -rf .parcel-cache",
     "format": "concurrently -c \"magenta,blue,green\" \"npm:format.tokens\" \"npm:format.assets\"",
     "format.assets": "eslint assets --fix && prettier --write assets",
     "format.tokens": "style-dictionary build --config style-dictionary.config.js",


### PR DESCRIPTION
## Overview
Adds `npm run clear-cache` to the scripts available to the theme. This is useful if Parcel seems unable to build/is complaining about missing files.

## How to Test
- [ ] Pull this PR to local
- [ ] Run `npm run clear-cache`
- [ ] See that the .parcel-cache directory is gone from the root theme directory.
- [ ] Run `npm run start` and make sure the directory is added back.