### PR TITLE
Fixing editor styles so that they can be used straight out of the theme

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,56 +1,15 @@
-/* Editor Styles */
-/* Tailwind Setup */
-/**
-* This injects Tailwind's base styles and any base styles registered by
-* plugins.
-*/
-@tailwind base;
 
-/**
-* This injects Tailwind's component classes and any component classes
-* registered by plugins.
-*/
-@tailwind components;
+/* Import all tailwind css. */
+@import "index.css";
 
-@layer {
-  .editor-styles-wrapper {
-    p,
-    ol,
-    ul,
-    dl,
-    blockquote,
-    pre,
-    table,
-    figure,
-    hr {
-      /* @apply font-text; */
-    }
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      /* @apply font-display; */
-    }
-    /* Editor Components */
-    @import "common/buttons-links.css";
-    @import "common/typography.css";
-  }
+/* Add any wp-admin specific overrides here! */
+.edit-post-visual-editor__post-title-wrapper h1 {
+  font-size: revert;
+  font-weight: revert;
+  margin: revert;
 }
 
-/* Tailwind Wrap-up */
-/**
-* This injects Tailwind's utility classes and any utility classes registered
-* by plugins.
-*/
-@tailwind utilities;
-
-/**
-* Use this directive to control where Tailwind injects the responsive
-* variations of each utility.
-*
-* If omitted, Tailwind will append these classes to the very end of
-* your stylesheet by default.
-*/
-@tailwind screens;
+.acf-field select,
+.acf-field textarea {
+  border: 1px solid #8c8f94;
+}

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -17,6 +17,7 @@ body {
   font-weight: var(--font-weight-light);
   line-height: var(--line-height-normal);
   font-style: normal;
+  width: 100%;
   max-width: var(--screen-site-max-width);
   min-height: 100vh;
   background-color: var(--color-white);

--- a/lib/class-theme.php
+++ b/lib/class-theme.php
@@ -65,7 +65,6 @@ class Theme extends Timber\Site {
 		add_action( 'after_setup_theme', [ $this, 'thinktimber_setup' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'thinktimber_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'thinktimber_admin_styles' ] );
-		add_action( 'enqueue_block_editor_assets', [ $this, 'thinktimber_block_editor_styles' ] );
 		add_filter( 'timber/context', [ $this, 'add_to_context' ] );
 		add_filter( 'timber/twig', [ $this, 'add_to_twig' ] );
 		add_filter( 'script_loader_tag', [ $this, 'thinktimber_defer_scripts' ], 10, 2 );
@@ -182,6 +181,9 @@ class Theme extends Timber\Site {
 		);
 
 		add_theme_support( 'menus' );
+
+		add_theme_support( 'editor-styles' );
+		add_editor_style( 'dist/motif-admin.css' );
 	}
 
 	/**
@@ -218,22 +220,6 @@ class Theme extends Timber\Site {
 		// Fonts.
 		wp_enqueue_style( 'thinktimber-fonts', 'https://use.typekit.net/kitId.css', [], $this->scripts_version );
 		wp_enqueue_script( 'thinktimber-font-awesome', 'https://kit.fontawesome.com/3d318b83b5.js', [], $this->scripts_version, false );
-	}
-
-	/**
-	 * Enqueue block editor scripts and styles.
-	 */
-	public function thinktimber_block_editor_styles() {
-		$splc_css_dependencies = [
-			'wp-block-library-theme',
-			'wp-block-library',
-		];
-
-		// Styles.
-		wp_enqueue_style( 'thinktimber-admin-styles', get_template_directory_uri() . "/$this->scripts_dir/motif-admin.css", $splc_css_dependencies, $this->scripts_version );
-
-		// Scripts.
-		wp_enqueue_script( 'thinktimber-admin-scripts', get_template_directory_uri() . "/$this->scripts_dir/motif-admin.js", [ 'wp-edit-post' ], $this->scripts_version, true );
 	}
 
 	/**

--- a/lib/class-theme.php
+++ b/lib/class-theme.php
@@ -64,7 +64,8 @@ class Theme extends Timber\Site {
 		add_action( 'after_setup_theme', [ $this, 'thinktimber_content_width' ], 0 );
 		add_action( 'after_setup_theme', [ $this, 'thinktimber_setup' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'thinktimber_scripts' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'thinktimber_admin_styles' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'thinktimber_admin_scripts' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'thinktimber_block_editor_scripts' ] );
 		add_filter( 'timber/context', [ $this, 'add_to_context' ] );
 		add_filter( 'timber/twig', [ $this, 'add_to_twig' ] );
 		add_filter( 'script_loader_tag', [ $this, 'thinktimber_defer_scripts' ], 10, 2 );
@@ -216,10 +217,22 @@ class Theme extends Timber\Site {
 	/**
 	 * Enqueue admin scripts and styles.
 	 */
-	public function thinktimber_admin_styles() {
+	public function thinktimber_admin_scripts() {
+		$scripts_version = '1.0.0';
+
 		// Fonts.
-		wp_enqueue_style( 'thinktimber-fonts', 'https://use.typekit.net/kitId.css', [], $this->scripts_version );
-		wp_enqueue_script( 'thinktimber-font-awesome', 'https://kit.fontawesome.com/3d318b83b5.js', [], $this->scripts_version, false );
+		wp_enqueue_style( 'thinktimber-fonts', 'https://use.typekit.net/kitId.css', [], $scripts_version );
+		wp_enqueue_script( 'thinktimber-font-awesome', 'https://kit.fontawesome.com/3d318b83b5.js', [], $scripts_version, false );
+	}
+
+	/**
+	 * Enqueue block editor scripts and styles.
+	 */
+	public function thinktimber_block_editor_scripts() {
+		$scripts_version = '1.0.0';
+
+		// Scripts.
+		wp_enqueue_script( 'thinktimber-admin-scripts', get_template_directory_uri() . "/dist/motif-admin.js", [ 'wp-edit-post' ], $scripts_version, true );
 	}
 
 	/**


### PR DESCRIPTION
Remove the custom admin styles setup and let wordpress do the hard work for us. There is a section with a couple of admin overrides in the admin css file, but otherwise I found that just using the main stylesheet directly works really well.

This setup is already on https://github.com/thinkshout/aiusa if it's helpful to look at an example!