### PR TITLE
Match content size with default breakpoints from screen.tokens.json

### DIFF
--- a/assets/css/base/_generated-variables.css
+++ b/assets/css/base/_generated-variables.css
@@ -31,8 +31,8 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
-  --font-family-serif: "Geller Headline", Times, serif;
-  --font-family-sans: "Halyard Text", Helvetica, Arial, sans-serif;
+  --font-family-serif: 'Geller Headline', Times, serif;
+  --font-family-sans: 'Halyard Text', Helvetica, Arial, sans-serif;
   --font-size-2xs: 0.625rem;
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
@@ -45,7 +45,7 @@
   --font-size-4xl: 2.5rem;
   --font-size-5xl: 2.8125rem;
   --font-size-6xl: 3.75rem;
-  --lh-10: 1;
+  --lh-10: 1.0;
   --lh-11: 1.1;
   --lh-12: 1.2;
   --lh-13: 1.3;

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -2,7 +2,7 @@ module.exports = {
   source: ["tokens/src/**/*.json"],
   format: {
     wordpressTheme: ({dictionary, platform}) => {
-      const { color, font } = dictionary.tokens;
+      const { color, font, screen } = dictionary.tokens;
       const theme = {
         $schema: "https://schemas.wp.org/trunk/theme.json",
         version: 2,
@@ -78,6 +78,13 @@ module.exports = {
             name: sizeName
           });
         });
+      }
+      // Set Layout Settings
+      if ( screen.siteMaxWidth ) {
+        theme.settings.layout.wideSize = screen.siteMaxWidth.value;
+      }
+      if ( screen.xl ) {
+        theme.settings.layout.contentSize = screen.xl.value;
       }
       return JSON.stringify(theme, null, 2);
     }

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -22,8 +22,8 @@ module.exports = {
             units: [ "px", "em", "rem", "vh", "vw" ]
           },
           layout: {
-            contentSize: "840px",
-            wideSize: "1100px"
+            contentSize: "1442px",
+            wideSize: "2000px"
           },
           blocks: {}
         }

--- a/theme.json
+++ b/theme.json
@@ -124,8 +124,8 @@
       ]
     },
     "layout": {
-      "contentSize": "840px",
-      "wideSize": "1100px"
+      "contentSize": "1442px",
+      "wideSize": "2000px"
     },
     "blocks": {}
   }


### PR DESCRIPTION
Just an idea. Does this make any sense?

The reason I switched these on https://github.com/thinkshout/aiusa is because then the block editor matches the desktop designs when you're editing.