### PR TITLE
Update directory list to match the current base build defaults.

### DIFF
--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -101,7 +101,12 @@ class StarterSite extends Site {
 	 * Modify ACF Gutenberg Blocks Template Location
 	 */
 	public function acf_gutenberg_blocks_template_location() {
-		return array( 'views/organisms/blocks' );
+		$theme_dir = get_template_directory();
+		foreach ( glob( $theme_dir . '/views/organisms/blocks/*', GLOB_ONLYDIR ) as $directory_path ) {
+			$directory = str_replace($theme_dir, "", $directory_path);
+			$paths[] = "$directory/controller";
+		}
+		return $paths;
 	}
 
 	/**

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -101,6 +101,7 @@ class StarterSite extends Site {
 	 * Modify ACF Gutenberg Blocks Template Location
 	 */
 	public function acf_gutenberg_blocks_template_location() {
+		$paths = array( 'views/organisms/blocks' );
 		$theme_dir = get_template_directory();
 		foreach ( glob( $theme_dir . '/views/organisms/blocks/*', GLOB_ONLYDIR ) as $directory_path ) {
 			$directory = str_replace($theme_dir, "", $directory_path);


### PR DESCRIPTION
We added more structure to our base build blocks, including a controller directory. This causes the gutenberg blocks thing to fail to find our twig templates, because they are one directory deeper. To get them to be recognized we have to get an actual list of the directory and add all the items.