### PR TITLE
Fixing includes for front page template

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,13 +15,9 @@ use Timber\Timber;
 $templates = [ 'templates/index.twig' ];
 
 if ( is_home() ) {
-	array_unshift( $templates, 'pages/front-page.twig', 'pages/home.twig' );
+	array_unshift( $templates, 'pages/home.twig' );
 }
 
-$context = Timber::context(
-	[
-		'foo' => 'bar',
-	]
-);
+$context = Timber::context( [] );
 
 Timber::render( $templates, $context );

--- a/page.php
+++ b/page.php
@@ -21,4 +21,10 @@ if ( 'style-guide' === $post->post_name ) {
 	$context['ts_blocks'] = $acf_block_types->get_data();
 }
 
-Timber::render( array( 'pages/page-' . $post->post_name . '.twig', 'pages/page.twig' ), $context );
+$templates = array( 'pages/page-' . $post->post_name . '.twig', 'pages/page.twig' );
+
+if ( is_front_page() ) {
+	array_unshift( $templates, 'pages/front-page.twig' );
+}
+
+Timber::render( $templates, $context );


### PR DESCRIPTION
The `front-page` template override wasn't working for a regular page set as the home page. This fixes that, and cleans up some of the code in index.php as well.