### PR TITLE
Adding twig namespace to template paths in the base theme

### DIFF
--- a/views/partials/comment.twig
+++ b/views/partials/comment.twig
@@ -3,13 +3,13 @@
     <div class="comment-content">{{ comment.content|wpautop }}</div>
 
     <section class="comment-box">
-        {% include 'partials/comment-form.twig' %}
+        {% include '@thinktimber/partials/comment-form.twig' %}
 
         {% if post.comments %}
             <h4>replies</h4>
             <div class="comments">
                 {% for cmt in comment.children %}
-                    {% include 'partials/comment.twig' with {
+                    {% include '@thinktimber/partials/comment.twig' with {
                         comment: cmt
                     } %}
                 {% endfor %}

--- a/views/partials/tease-post.twig
+++ b/views/partials/tease-post.twig
@@ -1,4 +1,4 @@
-{% extends 'partials/tease.twig' %}
+{% extends '@thinktimber/partials/tease.twig' %}
 
 {% block content %}
     <h2 class="h2"><a href="{{ post.link }}">{{ post.title }}</a></h2>

--- a/views/templates/404.twig
+++ b/views/templates/404.twig
@@ -1,4 +1,4 @@
-{% extends 'base.twig' %}
+{% extends '@thinktimber/base.twig' %}
 
 {% block content %}
     Sorry, we couldn't find what you're looking for.

--- a/views/templates/archive.twig
+++ b/views/templates/archive.twig
@@ -1,11 +1,11 @@
-{% extends 'base.twig' %}
+{% extends '@thinktimber/base.twig' %}
 
 {% block content %}
     {% for post in posts %}
-        {% include ['partials/tease-' ~ post.type ~ '.twig', 'partials/tease.twig'] %}
+        {% include ['@thinktimber/partials/tease-' ~ post.type ~ '.twig', '@thinktimber/partials/tease.twig'] %}
     {% endfor %}
 
-    {% include 'molecules/pagination/display/pagination--display.twig' with {
+    {% include '@thinktimber/molecules/pagination/display/pagination--display.twig' with {
         pagination: posts.pagination({
             show_all: false,
             mid_size: 3,

--- a/views/templates/author.twig
+++ b/views/templates/author.twig
@@ -1,7 +1,7 @@
-{% extends 'base.twig' %}
+{% extends '@thinktimber/base.twig' %}
 
 {% block content %}
     {% for post in posts %}
-        {% include ['partials/tease-' ~ post.type ~ '.twig', 'partials/tease.twig'] %}
+        {% include ['@thinktimber/partials/tease-' ~ post.type ~ '.twig', '@thinktimber/partials/tease.twig'] %}
     {% endfor %}
 {% endblock %}

--- a/views/templates/index.twig
+++ b/views/templates/index.twig
@@ -1,11 +1,11 @@
-{% extends 'base.twig' %}
+{% extends '@thinktimber/base.twig' %}
 
 {% block content %}
     {% for post in posts %}
-        {% include ['partials/tease-' ~ post.type ~ '.twig', 'partials/tease.twig'] %}
+        {% include ['@thinktimber/partials/tease-' ~ post.type ~ '.twig', '@thinktimber/partials/tease.twig'] %}
     {% endfor %}
 
-    {% include 'molecules/pagination/display/pagination--display.twig' with {
+    {% include '@thinktimber/molecules/pagination/display/pagination--display.twig' with {
         pagination: posts.pagination({
             show_all: false,
             mid_size: 3,

--- a/views/templates/search.twig
+++ b/views/templates/search.twig
@@ -1,13 +1,13 @@
 {# see `templates/archive.twig` for an alternative strategy of extending templates #}
-{% extends 'base.twig' %}
+{% extends '@thinktimber/base.twig' %}
 
 {% block content %}
     <div class="content-wrapper">
         {% for post in posts %}
-            {% include ['partials/tease-' ~ post.type ~ '.twig', 'partials/tease.twig'] %}
+            {% include ['@thinktimber/partials/tease-' ~ post.type ~ '.twig', '@thinktimber/partials/tease.twig'] %}
         {% endfor %}
 
-        {% include 'molecules/pagination/display/pagination--display.twig' with {
+        {% include '@thinktimber/molecules/pagination/display/pagination--display.twig' with {
             pagination: posts.pagination({
                 show_all: false,
                 mid_size: 3,

--- a/views/templates/single-password.twig
+++ b/views/templates/single-password.twig
@@ -1,4 +1,4 @@
-{% extends 'base.twig' %}
+{% extends '@thinktimber/base.twig' %}
 
 {% block content %}
     <form class="password-form"

--- a/views/templates/single.twig
+++ b/views/templates/single.twig
@@ -1,4 +1,4 @@
-{% extends 'base.twig' %}
+{% extends '@thinktimber/base.twig' %}
 
 {% block content %}
     <div class="content-wrapper">
@@ -19,7 +19,7 @@
                     {% if post.comments %}
                         <h3>comments</h3>
                         {% for cmt in post.comments %}
-                            {% include 'partials/comment.twig' with {
+                            {% include '@thinktimber/partials/comment.twig' with {
                                 comment: cmt
                             } %}
                         {% endfor %}
@@ -29,7 +29,7 @@
                 {% if post.comment_status == 'closed' %}
                     <p>comments for this post are closed</p>
                 {% else %}
-                    {% include 'partials/comment-form.twig' %}
+                    {% include '@thinktimber/partials/comment-form.twig' %}
                 {% endif %}
             </section>
         </article>


### PR DESCRIPTION
Not strictly necessary since these paths aren't used outside of this theme - but thought it would probably be best to keep these consistent with https://github.com/thinkshout/base-assets/pull/22