### PR TITLE
Drop "controller" directory usage (for ACF)

### DIFF
--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -106,11 +106,13 @@ class StarterSite extends Site {
 	 * Modify ACF Gutenberg Blocks Template Location
 	 */
 	public function acf_gutenberg_blocks_template_location() {
-		$paths = array( 'views/organisms/blocks' );
+		$paths = array( '/views/organisms/blocks' );
 		$theme_dir = get_template_directory();
 		foreach ( glob( $theme_dir . '/views/organisms/blocks/*', GLOB_ONLYDIR ) as $directory_path ) {
 			$directory = str_replace($theme_dir, "", $directory_path);
-			$paths[] = "$directory/controller";
+			if ( file_exists( $directory_path ) ) {
+				$paths[] = "$directory/styleguide";
+			}
 		}
 		return $paths;
 	}


### PR DESCRIPTION
Also, don't break when styleguide subdirectory is missing in one of the block directories.