### PR TITLE
Add a menu-flattening utility function.

### DIFF
--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -146,6 +146,7 @@ class StarterSite extends Site {
 		$context['menus']['header_utility_navigation'] = Timber::get_menu( 'utility_navigation' );
 		$context['menus']['footer_about'] = Timber::get_menu( 'about' );
 		$context['menus']['footer_copyright'] = Timber::get_menu( 'copyright' );
+		flatten_menu( $context['menus']['footer_copyright'] );
 		$context['site'] = $this;
 		$context['styleguide'] = is_page( 'style-guide' );
 
@@ -468,5 +469,36 @@ class StarterSite extends Site {
 		// $options['autoescape'] = true;
 
 		return $options;
+	}
+
+	/**
+	 * Take a hierarchical WP menu and flatten it.
+	 *
+	 * This is useful when a menu doesn't allow for sub-items. It just makes all
+	 * items top-level, in the order they appear in the admin UX. Thus, if a
+	 * site editor accidentally assigns a sub-item on one of these menus (due to
+	 * either not knowing what is allowed, or a dragging error, etc.) then the
+	 * menu item will still behave in an expected way.
+	 *
+	 * @param object $menu The menu object to be flattened.
+	 * @param array  $items The current set of child menu links to flatten in.
+	 *
+	 * @return void
+	 */
+	private function flatten_menu( &$menu, $items = false ) {
+		$add_current = (bool) $items;
+		if ( ! $items ) {
+			$items = $menu->get_items();
+		}
+		foreach ( $items as $menu_item ) {
+			$children = $menu_item->children;
+			if ( $add_current ) {
+				$menu_item->children = array();
+				$menu->items[] = $menu_item;
+			}
+			if ( ! empty( $children ) ) {
+				$this->flatten_menu( $menu, $children );
+			}
+		}
 	}
 }

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -146,7 +146,7 @@ class StarterSite extends Site {
 		$context['menus']['header_utility_navigation'] = Timber::get_menu( 'utility_navigation' );
 		$context['menus']['footer_about'] = Timber::get_menu( 'about' );
 		$context['menus']['footer_copyright'] = Timber::get_menu( 'copyright' );
-		flatten_menu( $context['menus']['footer_copyright'] );
+		$this->flatten_menu( $context['menus']['footer_copyright'] );
 		$context['site'] = $this;
 		$context['styleguide'] = is_page( 'style-guide' );
 
@@ -486,6 +486,9 @@ class StarterSite extends Site {
 	 * @return void
 	 */
 	private function flatten_menu( &$menu, $items = false ) {
+		if ( ! $menu ) {
+			return;
+		}
 		$add_current = (bool) $items;
 		if ( ! $items ) {
 			$items = $menu->get_items();


### PR DESCRIPTION
Designs regularly include menus that don't allow for submenus -- but the WP menu UX doesn't have a way to naturally restrict this behavior. This utility function simplifies this disconnect by stripping the hierarchical structure from a menu configuration before passing it off to the template system.

This was built originally on NSLIY: https://github.com/thinkshout/nsliy/pull/215

This PR also includes a usage of the utility on a menu where it seems it would naturally be desired in almost every site design. As a bonus, it's a fun example of recursion, which we rarely get to use ;)