### PR TITLE
Self-documenting components (WP version)

### DIFF
--- a/page.php
+++ b/page.php
@@ -15,27 +15,6 @@ use Timber\Timber;
 $context = Timber::context();
 $post = $context['post'];
 
-// Check if this is the style guide page.
-if ( 'style-guide' === $post->post_name ) {
-  $styleguide_directory_scans = array(
-    'ts_blocks' => '/views/organisms/blocks',
-    'ts_molecules' => '/views/molecules',
-  );
-  foreach( $styleguide_directory_scans as $context_label => $theme_path ) {
-    $context[$context_label] = [];
-    $directory = get_template_directory() . $theme_path;
-    $element_directories = scandir($directory);
-    if ($element_directories) {
-      foreach ($element_directories as $id) {
-        $styleguide_file = "$directory/$id/styleguide/$id--styleguide-layout.twig";
-        if ( file_exists( $styleguide_file ) ) {
-          $context[$context_label][$id] = ucfirst(str_replace('-', ' ', $id));
-        }
-      }
-    }
-  }
-}
-
 $templates = array( 'pages/page-' . $post->post_name . '.twig', 'pages/page.twig' );
 
 if ( is_front_page() ) {

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -188,6 +188,9 @@ class StarterSite extends Site {
 							'title' => 'Title',
 							'description' => 'Description',
 						) );
+						if ( ! $file_headers['title'] ) {
+							$file_headers['title'] = $id;
+						}
 						$file_headers['dev_notes'] = "$template_path/$id";
 						$file_headers['path'] = "$template_path/$styleguide_file";
 						$context[$context_label][$id] = $file_headers;

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -169,7 +169,32 @@ class StarterSite extends Site {
 		$context['menus']['footer_legal'] = Timber::get_menu( 'legal' );
 		$this->flatten_menu( $context['menus']['footer_legal'] );
 		$context['site'] = $this;
+
 		$context['styleguide'] = is_page( 'style-guide' );
+		if ( $context['styleguide'] ) {
+			$styleguide_directory_scans = array(
+				'ts_blocks' => 'organisms/blocks',
+				'ts_molecules' => 'molecules',
+			);
+			foreach( $styleguide_directory_scans as $context_label => $template_path ) {
+				$context[$context_label] = [];
+				$directory = get_template_directory() . '/views/' . $template_path;
+				$element_directories = scandir($directory) ?: array();
+				foreach ($element_directories as $id) {
+					$file = "$id/$id.twig";
+					$styleguide_file = "$id/styleguide/$id--styleguide-layout.twig";
+					if ( file_exists( "$directory/$styleguide_file" ) ) {
+						$file_headers = get_file_data( "$directory/$file", array(
+							'title' => 'Title',
+							'description' => 'Description',
+						) );
+						$file_headers['dev_notes'] = "$template_path/$id";
+						$file_headers['path'] = "$template_path/$styleguide_file";
+						$context[$context_label][$id] = $file_headers;
+					}
+				}
+			}
+		}
 
 		return $context;
 	}

--- a/views/templates/archive.twig
+++ b/views/templates/archive.twig
@@ -5,7 +5,7 @@
         {% include ['@thinktimber/partials/tease-' ~ post.type ~ '.twig', '@thinktimber/partials/tease.twig'] %}
     {% endfor %}
 
-    {% include '@thinktimber/molecules/pagination/display/pagination--display.twig' with {
+    {% include '@thinktimber/molecules/pagination/pagination.twig' with {
         pagination: posts.pagination({
             show_all: false,
             mid_size: 3,

--- a/views/templates/index.twig
+++ b/views/templates/index.twig
@@ -5,7 +5,7 @@
         {% include ['@thinktimber/partials/tease-' ~ post.type ~ '.twig', '@thinktimber/partials/tease.twig'] %}
     {% endfor %}
 
-    {% include '@thinktimber/molecules/pagination/display/pagination--display.twig' with {
+    {% include '@thinktimber/molecules/pagination/pagination.twig' with {
         pagination: posts.pagination({
             show_all: false,
             mid_size: 3,

--- a/views/templates/search.twig
+++ b/views/templates/search.twig
@@ -7,7 +7,7 @@
             {% include ['@thinktimber/partials/tease-' ~ post.type ~ '.twig', '@thinktimber/partials/tease.twig'] %}
         {% endfor %}
 
-        {% include '@thinktimber/molecules/pagination/display/pagination--display.twig' with {
+        {% include '@thinktimber/molecules/pagination/pagination.twig' with {
             pagination: posts.pagination({
                 show_all: false,
                 mid_size: 3,


### PR DESCRIPTION
This PR pairs with https://github.com/thinkshout/base-assets/pull/15 to automatically add molecules and blocks to the style guide, pulling in the title and description documentation from code to show on the style guide page.