### PR TITLE
Make the theme actually use its own dependencies

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -10,6 +10,11 @@
 
 namespace App;
 
+/**
+ * Prefer the theme's composer dependencies to the project's.
+ */
+require_once( realpath( __DIR__ ) . '/vendor/autoload.php' );
+
 use Timber\Timber;
 
 require_once __DIR__ . '/src/StarterSite.php';


### PR DESCRIPTION
If this is supposed to be happening somewhere else, please educate me, but it wasn't happening on my local until I added this.